### PR TITLE
Multiple output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ moc/
 Makefile
 *.pro
 multiTestsCaseRunner
-output.log
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Makefile
 *.pro
 multiTestsCaseRunner
 *.log
+*.out

--- a/MultiTests.hh
+++ b/MultiTests.hh
@@ -110,10 +110,10 @@ namespace MultiTests {
         return true;
     }
     /**
-     * @brief List all test function of an object
+     * @brief List all test function of a case
      * @param testObj - Pointer to the test object to list
      */
-    inline void listFunctionsTest(QObject * testObj){
+    inline void listTestFunctionsFromCase(QObject * testObj){
         qDebug() << "==" << qPrintable(testObj->objectName()) <<"==";
         for (int i = 0; i < testObj->metaObject()->methodCount(); ++i) {
             QMetaMethod sl = testObj->metaObject()->method(i);
@@ -184,7 +184,7 @@ namespace MultiTests {
         int ret = 0;
         QStringList failedTestCase;
         TestCasesList casesToRun;
-        QStringList argsList = argumentsToList(argc,argv);
+        QStringList arguments = argumentsToList(argc,argv);
 
 #if QT_VERSION >= 0x050000
         qApp->setAttribute(Qt::AA_Use96Dpi, true);
@@ -192,19 +192,19 @@ namespace MultiTests {
 
 
         QDateTime start = QDateTime::currentDateTime();
-        casesToRun = selectTestCasesToRun(argsList);
+        casesToRun = selectTestCasesToRun(arguments);
 
         // If option -functions, need a global running
-        if( argsList.contains("-functions") ){
+        if( arguments.contains("-functions") ){
             foreach (QObject* test, casesToRun){
-                listFunctionsTest(test);
+                listTestFunctionsFromCase(test);
             }
             return 0;
         }
 
         foreach (QObject* test,casesToRun){
             try {
-                int currentNbError = QTest::qExec(test,argsList);
+                int currentNbError = QTest::qExec(test,arguments);
                 if( currentNbError>0 ){
                     ret+= currentNbError;
                     failedTestCase.append( test->objectName() );

--- a/MultiTests.hh
+++ b/MultiTests.hh
@@ -128,15 +128,28 @@ namespace MultiTests {
     }
 
     /**
+     * @brief Transform the C arguments list style to a QStringList
+     * @param argc - Count of arguments
+     * @param argv - Array of arguments
+     * @return A QStringList of arguments
+     */
+    inline QStringList argumentsToList(int argc, char *argv[]) {
+        QStringList argsList;
+        for(int argIndex=0;argIndex<argc;argIndex++ ){
+            argsList.append( argv[argIndex] );
+        }
+        return argsList;
+    }
+
+    /**
      * @brief Run tests cases depending on some command lines options
      */
     inline int run(int argc, char *argv[]) {
         int ret = 0;
         int argCaseIndex = 0;
-        int nbTestClass = 0;
         QStringList failedTestCase;
         TestCasesList testsToRun;
-        QStringList argsList;
+        QStringList argsList = argumentsToList(argc,argv);
 
 #if QT_VERSION >= 0x050000
         qApp->setAttribute(Qt::AA_Use96Dpi, true);
@@ -144,13 +157,9 @@ namespace MultiTests {
 
 
         QDateTime start = QDateTime::currentDateTime();
-        for(int argIndex=0;argIndex<argc;argIndex++ ){
-            argsList.append( argv[argIndex] );
-        }
 
         if( argContain(argsList,"-case",&argCaseIndex) && (argCaseIndex+1)<argsList.size() ){
             // At least one Argument "-case" specify a test case for run only it
-
             while( argContain(argsList,"-case",&argCaseIndex) && (argCaseIndex+1)<argsList.size() ){
                 QString testNameToRun = argsList.at(argCaseIndex+1);
                 QObject * specifiedTest = findTestName(testNameToRun);
@@ -194,7 +203,6 @@ namespace MultiTests {
             catch(...){
                 ret++;
             }
-            nbTestClass++;
         }
 
         int nbMsecs = start.msecsTo( QDateTime::currentDateTime() );
@@ -206,12 +214,12 @@ namespace MultiTests {
             qCritical() << "======= ERRORS during tests !!!   =======";
             qCritical() << qPrintable(
                                 QString("%1 error in %2 case(s), over a total of %3 tests cases")
-                                .arg(ret).arg(failedTestCase.size()).arg(nbTestClass));
+                                .arg(ret).arg(failedTestCase.size()).arg(testsToRun.size()));
             qCritical() << "Case(s) that failed : " << qPrintable(failedTestCase.join(" / "));
         }
         else{
             qWarning() << qPrintable(
-                    QString("======= All tests succeed (%1 tests cases)  =======").arg(nbTestClass));
+                    QString("======= All tests succeed (%1 tests cases)  =======").arg(testsToRun.size()));
         }
         qWarning() << qPrintable(
                 QString("Executed in %1 seconds (%2 ms)").arg(nbSecs).arg(nbMsecs));

--- a/tests/outputOptionCreateFile/singleCase.hh
+++ b/tests/outputOptionCreateFile/singleCase.hh
@@ -1,0 +1,21 @@
+ #ifndef TESTDUMMY_HH_
+#define TESTDUMMY_HH_
+
+#include "../../MultiTests.hh"
+
+class Dummy_test : public QObject{
+    Q_OBJECT
+
+    private slots:
+        // Test functions
+        void obviousTest(void){
+            QCOMPARE(1,1);
+        }
+};
+
+TEST_DECLARE(Dummy_test);
+
+
+MULTI_TESTS_MAIN
+
+#endif /* TESTDUMMY_HH_ */

--- a/tests/outputOptionCreateFile/test.conf
+++ b/tests/outputOptionCreateFile/test.conf
@@ -1,0 +1,3 @@
+runnerOptions="-o test.out"
+checkNbCases="0"
+checksFileExist+=("Force output to file"="test.out")

--- a/tests/outputOptionOnMultipleCase/firstCase.hh
+++ b/tests/outputOptionOnMultipleCase/firstCase.hh
@@ -1,0 +1,31 @@
+#ifndef FIRSTCASE_HH_
+#define FIRSTCASE_HH_
+
+#include "../../MultiTests.hh"
+
+#include <QString>
+
+class FirstCase_test : public QObject{
+    Q_OBJECT
+
+    private slots:
+        // Test functions
+        void regExTestser(void){
+            QString regEx = ".*_\\d+$";
+            
+            QVERIFY( !QString("test").contains( QRegExp(regEx) ) );
+            QVERIFY( !QString("test1").contains( QRegExp(regEx) ) );
+            QVERIFY( QString("test_1").contains( QRegExp(regEx) ) );
+            QVERIFY( QString("test_00").contains( QRegExp(regEx) ) );
+            QVERIFY( QString("test_11").contains( QRegExp(regEx) ) );
+            QVERIFY( QString("test_00001").contains( QRegExp(regEx) ) );
+            QVERIFY( !QString("test_a").contains( QRegExp(regEx) ) );
+            QVERIFY( !QString("test_ad1").contains( QRegExp(regEx) ) );
+            QVERIFY( QString("test_1_1").contains( QRegExp(regEx) ) );
+            QVERIFY( !QString("test_1_a").contains( QRegExp(regEx) ) );
+        }
+};
+
+TEST_DECLARE(FirstCase_test);
+
+#endif /* FIRSTCASE_HH_ */

--- a/tests/outputOptionOnMultipleCase/main.cpp
+++ b/tests/outputOptionOnMultipleCase/main.cpp
@@ -1,0 +1,6 @@
+
+#include "firstCase.hh"
+#include "secondCase.hh"
+#include "thirdCase.hh"
+
+MULTI_TESTS_MAIN

--- a/tests/outputOptionOnMultipleCase/secondCase.hh
+++ b/tests/outputOptionOnMultipleCase/secondCase.hh
@@ -1,0 +1,18 @@
+#ifndef SECONDCASE_HH_
+#define SECONDCASE_HH_
+
+#include "../../MultiTests.hh"
+
+class SecondCase_test : public QObject{
+    Q_OBJECT
+
+    private slots:
+        // Test functions
+        void obviousTest(void){
+            QCOMPARE(1,1);
+        }
+};
+
+TEST_DECLARE(SecondCase_test);
+
+#endif /* SECONDCASE_HH_ */

--- a/tests/outputOptionOnMultipleCase/test.conf
+++ b/tests/outputOptionOnMultipleCase/test.conf
@@ -1,0 +1,5 @@
+runnerOptions="-o testoutput.out"
+checkNbCases="0"
+checksFileExist+=("First case summary is inside a file"="testoutput.out")
+checksFileExist+=("Second case summary is inside a file"="testoutput_0001.out")
+checksFileExist+=("Third case summary is inside a file"="testoutput_0002.out")

--- a/tests/outputOptionOnMultipleCase/thirdCase.hh
+++ b/tests/outputOptionOnMultipleCase/thirdCase.hh
@@ -1,0 +1,18 @@
+#ifndef THIRDCASE_HH_
+#define THIRDCASE_HH_
+
+#include "../../MultiTests.hh"
+
+class ThirdCase_test : public QObject{
+    Q_OBJECT
+
+    private slots:
+        // Test functions
+        void obviousTest(void){
+            QCOMPARE(1,1);
+        }
+};
+
+TEST_DECLARE(ThirdCase_test);
+
+#endif /* THIRDCASE_HH_ */

--- a/tests/resultParsing.sh
+++ b/tests/resultParsing.sh
@@ -44,3 +44,15 @@ testLogContain(){
         error "$2 : log do not contain '$1'"
     fi
 }
+
+testFileExist(){
+    # Test that a file exist
+    # param1 : The file name
+    # param2 : Description of test
+    if [ -e "$1" ]
+    then
+        log "$2 : File '$1' exist"
+    else
+        error "$2 : File '$1' do not exist"
+    fi
+}

--- a/tests/runAll.sh
+++ b/tests/runAll.sh
@@ -108,6 +108,9 @@ testConfigurationUnset(){
     # Pseudo-Associative map of checks for log content
     unset checksStr
     declare -a checksStr
+    # Pseudo-Associative map of checks for file exists
+    unset checksFileExist
+    declare -a checksFileExist
 }
 
 testConfigurationLoad(){
@@ -129,6 +132,12 @@ testChecks(){
         local key=${currentCheckStr%%=*}
         local value=${currentCheckStr#*=}
         testLogContain "$value" "$key"
+    done
+
+    for currentCheckFileExist in "${checksFileExist[@]}" ; do
+        local key=${currentCheckFileExist%%=*}
+        local value=${currentCheckFileExist#*=}
+        testFileExist "$value" "$key"
     done
 }
 

--- a/tests/runAll.sh
+++ b/tests/runAll.sh
@@ -80,6 +80,7 @@ projectClean(){
     rm -f $BIN_RUNNER $RUNNER_OUTPUT
     rm -f Makefile *.pro
     rm -rf moc/ obj/
+    rm -rf *.log *.out
 }
 projectPrepare(){
     qmake -project


### PR DESCRIPTION
When triggering the `-o` option (output tests results to a file) and having multiple tests case, the default behaviour was to override the file content with the last case running.

Now we modify the output file name for insert suffix (case index) 
Like that the output result is a file for each test case of a suite 

For example running `testsuite -xml -o output.xml` over 3 test cases will produce : 
`output.xml` for the first case, then `output_0001.xml` and `output_0002.xml`

This solve mostly #5 'File splitting' section

It can be discuss on add a suffix for the first case. 

A known problem is if the requested output file name is already following the same pattern : 
- `testsuite -xml -o output_2.xml` : produce `output_2.xml` (first case), `output_0001.xml` `output_0002.xml`
- `testsuite -xml -o output_0001.xml` : produce `output_0012.xml` (first case), `output_0001.xml` (override file content) and `output_0002.xml`
